### PR TITLE
Added News Bundler

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A collection of awesome email newsletter tools, platforms, media, and software.
   - [Inbox Management](#inbox-management)
   - [Platforms](#platforms)
       - [Blog-first](#blog-first)
+      - [Bundling](#bundling)
       - [Editorial](#editorial)
       - [Marketing](#marketing)
       - [Open source](#open-source)
@@ -50,6 +51,7 @@ A collection of awesome email newsletter tools, platforms, media, and software.
 - [Letterdrop](https://letterdrop.io/) - list of recently launched newsletters
 - [Letterlist](https://letterlist.com/) - curated list of newsletters with interviews
 - [mereku](http://mereku.com/) - discover and share newsletter content worth reading
+- [News Bundler](https://newsbundler.com/) - directory with the ability to create bundles
 - [Newsletter Junkie](https://newsletterjunkie.com/) - curated list of newsletters with topics
 - [Newsletter Stack](https://newsletterstack.com/) - list of curated newsletters with topics
 - [Newsletterest](https://newsletterest.com/) - list of newsletters with functionality to see past issues
@@ -80,6 +82,10 @@ A collection of awesome email newsletter tools, platforms, media, and software.
 
 - [Ghost](https://ghost.org/) - popular CMS for building blogs
 - [Wordpress](https://wordpress.com/) - popular CMS for building sites and blogs
+
+#### Bundling
+
+- [News Bundler](https://newsbundler.com/) - team up with another newsletter author and increase your reveneue by selling a newsletter bundle
 
 #### Editorial
 


### PR DESCRIPTION
Added a new category of platforms: Bundling

- Authors team up with one another to increase their revenue by selling newsletter bundles.
- Works by joining their lists and sharing the increased revenue. 36% of a cake of size 4 is more than 100% of a cake of size 1.
- Subscribers get a discount for multiple newsletters.